### PR TITLE
Fix the release command

### DIFF
--- a/.github/workflows/backend-release.yml
+++ b/.github/workflows/backend-release.yml
@@ -29,4 +29,4 @@ jobs:
         run: flyctl deploy
 
       - name: Migrate the database
-        run: flyctl ssh console --command "cd /app; alembic upgrade head"
+        run: echo "cd /app; alembic upgrade head; exit" | flyctl ssh console --command "/bin/bash"


### PR DESCRIPTION
## Description

For whatever reason, the `ssh console` command now starts the terminal at `/` instead of inside the Docker defined workdir. This PR makes sure that the terminal is always in `/app` to run the migration command.

## Requirements

None.

## Additional changes

None.