### PR TITLE
Remove env variable

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -7,7 +7,6 @@ processes = []
 
 [env]
   PORT = 8080
-  ALLOWED_ORIGINS = "https://split.daleal.dev"
 
 [experimental]
   allowed_public_ports = []


### PR DESCRIPTION
## Description

Remove allowed origins from fly.toml file as it is now a secret

## Requirements

The `ALLOWED_ORIGINS` variable now needs to be configured using Fly.io secrets.

## Additional changes

None.
