### PR TITLE
Make parsers more robust

### DIFF
--- a/backend/split/services/receipt_parser/cleaner.py
+++ b/backend/split/services/receipt_parser/cleaner.py
@@ -1,7 +1,6 @@
 import re
 from functools import reduce
 
-
 DENIED_PATTERNS_LIST = [
     re.compile(r"(^|\s+)\d{1,2} del? 20\d{2}($|\s+)"),  # human-readable dates
     re.compile(r"(^|\s+)(20)?\d{2}-\d{2}-(20)?\d{2}($|\s+)"),  # dates

--- a/backend/split/services/receipt_parser/cleaner.py
+++ b/backend/split/services/receipt_parser/cleaner.py
@@ -11,6 +11,9 @@ CHARACTERS_TO_REMOVE = [
     ".",
     ",",
     "$",
+    "€",
+    "¥",
+    "¢",
     "“",
     "‘",
     "’",
@@ -38,8 +41,6 @@ CHARACTERS_TO_REPLACE_WITH_SPACE = [
     "«",
     "»",
     "©",
-    "¥",
-    "¢",
 ]
 
 REGEX_TO_REMOVE = re.compile("|".join(re.escape(x) for x in CHARACTERS_TO_REMOVE))

--- a/backend/split/services/receipt_parser/cleaner.py
+++ b/backend/split/services/receipt_parser/cleaner.py
@@ -2,9 +2,9 @@ import re
 from functools import reduce
 
 DENIED_PATTERNS_LIST = [
-    re.compile(r"\s\d{1,2} del? 20\d{2}\s?"),  # human-readable dates
-    re.compile(r"\s(20)?\d{2}-\d{2}-(20)?\d{2}\s?"),  # dates
-    re.compile(r"\s(20)?\d{2}/\d{2}/(20)?\d{2}\s?"),  # dates
+    re.compile(r"(^|\s+)\d{1,2} del? 20\d{2}($|\s+)"),  # human-readable dates
+    re.compile(r"(^|\s+)(20)?\d{2}-\d{2}-(20)?\d{2}($|\s+)"),  # dates
+    re.compile(r"(^|\s+)(20)?\d{2}/\d{2}/(20)?\d{2}($|\s+)"),  # dates
 ]
 
 

--- a/backend/split/services/receipt_parser/cleaner.py
+++ b/backend/split/services/receipt_parser/cleaner.py
@@ -48,7 +48,10 @@ REGEX_TO_REPLACE_WITH_SPACE = re.compile(
 )
 
 CUSTOM_REPLACEMENTS = [
-    lambda text: re.sub(r"((^|\s+)\d+)(\.|,)\d{1,2}($|\s+)", r"\1\4", text),  # decimals
+    # dot + space in between only digits to only dot
+    lambda text: re.sub(r"((^|\s+)\d+)(\.|,) (\d+)($|\s+)", r"\1\3\4\5", text),
+    # two decimals to only integer
+    lambda text: re.sub(r"((^|\s+)\d+)(\.|,)\d{1,2}($|\s+)", r"\1\4", text),
 ]
 
 

--- a/backend/split/services/receipt_parser/cleaner.py
+++ b/backend/split/services/receipt_parser/cleaner.py
@@ -1,12 +1,12 @@
 import re
 from functools import reduce
 
+
 DENIED_PATTERNS_LIST = [
     re.compile(r"(^|\s+)\d{1,2} del? 20\d{2}($|\s+)"),  # human-readable dates
     re.compile(r"(^|\s+)(20)?\d{2}-\d{2}-(20)?\d{2}($|\s+)"),  # dates
     re.compile(r"(^|\s+)(20)?\d{2}/\d{2}/(20)?\d{2}($|\s+)"),  # dates
 ]
-
 
 CHARACTERS_TO_REMOVE = [
     ".",
@@ -43,14 +43,13 @@ CHARACTERS_TO_REPLACE_WITH_SPACE = [
     "¢",
 ]
 
-
 REGEX_TO_REMOVE = re.compile("|".join(re.escape(x) for x in CHARACTERS_TO_REMOVE))
 REGEX_TO_REPLACE_WITH_SPACE = re.compile(
     "|".join(re.escape(x) for x in CHARACTERS_TO_REPLACE_WITH_SPACE)
 )
 
 CUSTOM_REPLACEMENTS = [
-    lambda text: re.sub(r"(\s\d+)(\.|,)\d{1,2}\s", r"\1", text),  # remove decimals
+    lambda text: re.sub(r"((^|\s+)\d+)(\.|,)\d{1,2}($|\s+)", r"\1\4", text),  # decimals
 ]
 
 

--- a/backend/split/services/receipt_parser/parser.py
+++ b/backend/split/services/receipt_parser/parser.py
@@ -16,6 +16,7 @@ DENIED_WORDS_LIST = [
     "sugerida",
     "local",
     "tienda",
+    "cliente",
 ]
 
 DENIED_WORDS_EXPRESSION = re.compile("|".join(DENIED_WORDS_LIST), re.IGNORECASE)


### PR DESCRIPTION
## Description

Identify dates and decimals even when they start or end the line. Also add a new denied word to the denied list.

Also, handle the following parse imperfection:

```
10. 990 => 10.990
```

Remove the space after a dot (or a comma) when the surrounding elements are just digits.

## Requirements

None.

## Additional changes

None.
