### PR TITLE
Escape unicode characters

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -550,6 +550,14 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "unidecode"
+version = "1.3.6"
+description = "ASCII transliterations of Unicode text"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "uvicorn"
 version = "0.18.3"
 description = "The lightning-fast ASGI server."
@@ -575,7 +583,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "bbe346781236bf8e48cd60f5d2b781ea2e7c5cbf3f6a93b95565218e27f66a5b"
+content-hash = "af51893fc637767dfc7e2bf2f13471b9389e3b066fb4e28565c9c8740d05b7b3"
 
 [metadata.files]
 alembic = []
@@ -622,5 +630,6 @@ starlette = []
 tomli = []
 tomlkit = []
 typing-extensions = []
+unidecode = []
 uvicorn = []
 wrapt = []

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,7 @@ SQLAlchemy = "^1.4.41"
 alembic = "^1.8.1"
 psycopg2-binary = "^2.9.4"
 receipt-scanner = "^0.3.2"
+Unidecode = "^1.3.6"
 
 [tool.poetry.dev-dependencies]
 black = "^22.10.0"

--- a/backend/split/services/receipt_parser/cleaner.py
+++ b/backend/split/services/receipt_parser/cleaner.py
@@ -1,6 +1,8 @@
 import re
 from functools import reduce
 
+from unidecode import unidecode
+
 DENIED_PATTERNS_LIST = [
     re.compile(r"(^|\s+)\d{1,2} del? 20\d{2}($|\s+)"),  # human-readable dates
     re.compile(r"(^|\s+)(20)?\d{2}-\d{2}-(20)?\d{2}($|\s+)"),  # dates
@@ -71,9 +73,10 @@ def clean_string(string: str) -> str:
         string,
     )
     string_with_no_large_numbers = re.sub(r"[0-9]{7,}", "", custom_replacements)
+    ascii_string = unidecode(string_with_no_large_numbers)
     string_with_removed_characters = REGEX_TO_REMOVE.sub(
         "",
-        string_with_no_large_numbers,
+        ascii_string,
     )
     string_with_replaced_characters = REGEX_TO_REPLACE_WITH_SPACE.sub(
         " ",

--- a/backend/split/services/receipt_parser/parser.py
+++ b/backend/split/services/receipt_parser/parser.py
@@ -22,7 +22,7 @@ DENIED_WORDS_LIST = [
 DENIED_WORDS_EXPRESSION = re.compile("|".join(DENIED_WORDS_LIST), re.IGNORECASE)
 
 DESCRIPTION_EXPRESSION_FRAGMENT = (
-    r"(?P<description>\d*[a-zA-Z\(\)][a-zA-Z0-9 \(\)]{3,}[a-zA-Z\(\)])"
+    r"(?P<description>\d*[a-zA-Z\(\)][a-zA-Z0-9 \(\)]+[a-zA-Z\(\)])"
 )
 AMOUNT_EXPRESSION_FRAGMENT = r"(?P<amount>[0-9]{1,3})"
 FULL_PRICE_EXPRESSION_FRAGMENT = (


### PR DESCRIPTION
## Description

Escape unicode characters to ASCII only. Also lower the minimum amount of characters needed to parse a value (from 5 to 3)

## Requirements

None.

## Additional changes

None.
