### PR TITLE
Fix parsing errors

### DIFF
--- a/backend/split/services/receipt_parser/cleaner.py
+++ b/backend/split/services/receipt_parser/cleaner.py
@@ -30,6 +30,7 @@ CHARACTERS_TO_REMOVE = [
     "!",
     "¿",
     "?",
+    "@",
 ]
 CHARACTERS_TO_REPLACE_WITH_SPACE = [
     "*",

--- a/backend/split/services/receipt_parser/cleaner.py
+++ b/backend/split/services/receipt_parser/cleaner.py
@@ -57,7 +57,7 @@ REGEX_TO_REPLACE_WITH_SPACE = re.compile(
 
 CUSTOM_REPLACEMENTS = [
     # dot + space in between only digits to only dot
-    lambda text: re.sub(r"((^|\s+)\d+)(\.|,) (\d+)($|\s+)", r"\1\3\4\5", text),
+    lambda text: re.sub(r"((^|\s+)\$?\d+)(\.|,) (\d+)($|\s+)", r"\1\3\4\5", text),
     # two decimals to only integer
     lambda text: re.sub(r"((^|\s+)\d+)(\.|,)\d{1,2}($|\s+)", r"\1\4", text),
 ]

--- a/backend/split/services/receipt_parser/cleaner.py
+++ b/backend/split/services/receipt_parser/cleaner.py
@@ -43,6 +43,7 @@ CHARACTERS_TO_REPLACE_WITH_SPACE = [
     "_",
     "-",
     "—",
+    "~",
     "<",
     ">",
     "«",

--- a/backend/split/services/receipt_parser/parser.py
+++ b/backend/split/services/receipt_parser/parser.py
@@ -24,9 +24,9 @@ DENIED_WORDS_EXPRESSION = re.compile("|".join(DENIED_WORDS_LIST), re.IGNORECASE)
 DESCRIPTION_EXPRESSION_FRAGMENT = (
     r"(?P<description>\d* ?[a-zA-Z\(\)][a-zA-Z0-9 \(\)]+[a-zA-Z\(\)])"
 )
-AMOUNT_EXPRESSION_FRAGMENT = r"(?P<amount>[0-9]{1,3})"
+AMOUNT_EXPRESSION_FRAGMENT = r"(?P<amount>[0-9]{1,2})"
 FULL_PRICE_EXPRESSION_FRAGMENT = (
-    r"((?P<price_1>[0-9]{4,6})(\s+(?P<price_2>[0-9]{4,6}))?)"
+    r"((?P<price_1>[0-9]{3,6})(\s+(?P<price_2>[0-9]{3,6}))?)"
 )
 SEPARATOR = r"\s+"
 
@@ -102,7 +102,7 @@ def search(string: str) -> dict[str, str | int] | None:
             price_1 = int(raw_result["price_1"])
             price_2 = int(raw_result["price_2"] or "0")
             full_price = max(price_1, price_2)
-            if full_price < 1000:
+            if full_price < 100:
                 return None
             final_result: dict[str, str | int] = {
                 "description": raw_result["description"],


### PR DESCRIPTION
## Description

Correctly parse numbers on receipts that include spaces after dots when the number has a `$` before the number itself. Also remove some unwanted characters. Also change max digits allowed for amounts (from 3 to 2) and min digits allowed for prices (from 4 to 3)

## Requirements

None.

## Additional changes

None.
